### PR TITLE
fix(deps): fix critical security vulnerability in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,8 @@
   },
   "resolutions": {
     "@semantic-release/git/micromatch/braces": "3.0.3",
-    "mocha/chokidar/braces": "3.0.3"
-  }
+    "mocha/chokidar/braces": "3.0.3",
+    "lodash": "^4.18.1"
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1172,10 +1172,10 @@ lodash.set@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
-lodash@^4.1.2, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.1.2, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary

Addresses critical dependency vulnerability identified by Aikido Security.

| Package | From | To | Type | Severity | CVE |
|---------|------|----|------|----------|-----|
| lodash | 4.17.21 | 4.18.1 | transitive (via typedoc-plugin-external-module-name, typedoc, @semantic-release/git, nyc > @babel/core) | Critical | CVE-2026-4800 |

## Approach

- Added `resolutions` entry `"lodash": "^4.18.1"` to `package.json` to enforce the patched version across all transitive consumers.
- Minor patch upgrade within the `^4.17.x` compatibility range — no breaking changes.
- All 506 tests pass.

## Test plan

- [x] `yarn install` completed successfully
- [x] `yarn why lodash` confirms resolved version is `4.18.1`
- [x] `yarn test-mocha` — 506 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager metadata and enhanced dependency resolution configuration to improve consistency across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->